### PR TITLE
Slack api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@connectifi/sdk": "0.1.1",
         "@middy/core": "^6.0.0",
         "@middy/http-json-body-parser": "^6.0.0",
+        "@slack/web-api": "^7.8.0",
         "openai": "^4.71.1"
       },
       "devDependencies": {
@@ -2315,6 +2316,61 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@slack/logger": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
+      "integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+      "dependencies": {
+        "@types/node": ">=18.0.0"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.14.0.tgz",
+      "integrity": "sha512-n0EGm7ENQRxlXbgKSrQZL69grzg1gHLAVd+GlRVQJ1NSORo0FrApR7wql/gaKdu2n4TO83Sq/AmeUOqD60aXUA==",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.8.0.tgz",
+      "integrity": "sha512-d4SdG+6UmGdzWw38a4sN3lF/nTEzsDxhzU13wm10ejOpPehtmRoqBKnPztQUfFiWbNvSb4czkWYJD4kt+5+Fuw==",
+      "dependencies": {
+        "@slack/logger": "^4.0.0",
+        "@slack/types": "^2.9.0",
+        "@types/node": ">=18.0.0",
+        "@types/retry": "0.12.0",
+        "axios": "^1.7.8",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.0",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "2.0.15",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.15.tgz",
@@ -3106,6 +3162,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -3731,10 +3792,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "dev": true,
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -6075,6 +6135,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
     "node_modules/events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -6539,7 +6604,6 @@
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
       "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -7254,6 +7318,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -9201,7 +9270,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -9266,11 +9334,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-timeout": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "dev": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -9578,8 +9677,7 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -9861,6 +9959,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@connectifi/sdk": "0.1.1",
     "@middy/core": "^6.0.0",
     "@middy/http-json-body-parser": "^6.0.0",
+    "@slack/web-api": "^7.8.0",
     "openai": "^4.71.1"
   },
   "devDependencies": {

--- a/workspaces/common/src/actions/data/slack/channels.ts
+++ b/workspaces/common/src/actions/data/slack/channels.ts
@@ -1,0 +1,84 @@
+import { WebClient } from '@slack/web-api';
+import { ServerError, Channel, List } from '../../../types';
+
+
+export interface SlackChannel {
+    "id": string;
+    "name": string;
+    "is_channel": boolean;
+    "is_group": boolean;
+    "is_im": boolean;
+    "created": number;
+    "creator": string;
+    "is_archived": boolean;
+    "is_general": boolean;
+}
+
+export const getSlackChannels = async (apiKey: string): Promise<SlackChannel[]> => {
+    const slack = new WebClient(apiKey);
+    const channelsResponse = await slack.conversations.list();
+    if (channelsResponse.ok) {
+        return channelsResponse.channels.map((c) => {
+            return {
+                id: c.id,
+                name: c.name,
+                is_channel: c.is_channel,
+                is_group: c.is_group,
+                is_im: c.is_im,
+                created: c.created,
+                creator: c.creator,
+                is_archived:  c.is_archived,
+                is_general: c.is_general
+            }
+        });
+    }
+};
+
+//getChannels
+export const getChannels = async (apiKey:  string): Promise<List> => {
+    const slackChannels = await getSlackChannels(apiKey);
+    const channels: Array<Channel> = slackChannels.map((c) => {
+        return {
+            type: 'connect.channel',
+            name: c.name,
+            id: {
+                slack:  c.id
+            }
+        } as Channel;
+    });
+    return {
+        type: "connect.list",
+        listType: "connect.channel",
+        items: channels
+    }
+}
+
+//getOrCreateChannel
+export const getOrCreateChannel = async (apiKey:  string, name: string): Promise<Channel> => {
+    let found: SlackChannel | undefined;
+    const channels = await getSlackChannels(apiKey);
+    found = channels.find((channel)=> {
+        return (channel.name === name);
+    });
+    if (found){
+        return  {
+            name: found.name,
+            id: {
+                slack: found.id
+            }
+        } as Channel;
+    }
+    const slackAPI = new WebClient(apiKey);
+    const channelResponse = await slackAPI.conversations.create({
+        name: name
+    });  
+    if (channelResponse.ok){
+        return  {
+            name: channelResponse.channel.name,
+            id: {
+                slack: channelResponse.channel.id
+            }
+        } as Channel;
+    }
+    throw new ServerError('channel could not be found or created');
+};

--- a/workspaces/common/src/actions/data/slack/common.ts
+++ b/workspaces/common/src/actions/data/slack/common.ts
@@ -1,0 +1,5 @@
+import { Context } from '@finos/fdc3';
+
+export const contextToChannelName = (context: Context): string => {
+  return context.type.replace(".", "-");
+};

--- a/workspaces/common/src/actions/data/slack/common.ts
+++ b/workspaces/common/src/actions/data/slack/common.ts
@@ -1,5 +1,0 @@
-import { Context } from '@finos/fdc3';
-
-export const contextToChannelName = (context: Context): string => {
-  return context.type.replace(".", "-");
-};

--- a/workspaces/common/src/actions/data/slack/index.ts
+++ b/workspaces/common/src/actions/data/slack/index.ts
@@ -1,0 +1,45 @@
+import { DataActionHandler } from '@connectifi/sdk';
+import { postToContextChannel, postToChannel } from './messages';
+import { getChannels, getOrCreateChannel } from './channels';
+import { getUsers } from './users';
+import { getMessageTargets } from './messages';
+import { ServerError, RequestError, ChannelMessage } from '../../../types';
+
+const apiKey = process.env.SLACK_API_KEY;
+
+export const slackAPIHandler: DataActionHandler = async (params) => {
+  if (!apiKey) {
+    throw new ServerError('slack api key missing');
+  }
+  
+  const { context, intent } = { ...params };
+
+  if (intent === "PostToChannel") {
+    //if context is to post to a specific channel
+    if (context.type === "connect.channelMessage"){
+      const result = await postToChannel(apiKey, context as ChannelMessage);
+      return result;
+    }
+    //default to generic channel posting
+    const result = await postToContextChannel(apiKey, context);
+    return result;
+  }
+
+  if (intent == "GetChannels"){
+    return await getChannels(apiKey);
+  }
+
+  if (intent === "GetOrCreateChannel"){
+    return await getOrCreateChannel(apiKey, context.name);
+  }
+
+  if (intent === "GetUsers"){
+    return await getUsers(apiKey);
+  }
+
+  if (intent === "GetMessageTargets"){
+    return await getMessageTargets(apiKey);
+  }
+
+  throw new RequestError('intent not supported');
+};

--- a/workspaces/common/src/actions/data/slack/index.ts
+++ b/workspaces/common/src/actions/data/slack/index.ts
@@ -1,9 +1,9 @@
 import { DataActionHandler } from '@connectifi/sdk';
-import { postToContextChannel, postToChannel } from './messages';
+import { postToContextChannel, postToChannel, postToChat } from './messages';
 import { getChannels, getOrCreateChannel } from './channels';
 import { getUsers } from './users';
 import { getMessageTargets } from './messages';
-import { ServerError, RequestError, ChannelMessage } from '../../../types';
+import { ServerError, RequestError, ChannelMessage, ChatMessage } from '../../../types';
 
 const apiKey = process.env.SLACK_API_KEY;
 
@@ -22,6 +22,11 @@ export const slackAPIHandler: DataActionHandler = async (params) => {
     }
     //default to generic channel posting
     const result = await postToContextChannel(apiKey, context);
+    return result;
+  }
+
+  if (intent === "PostToChat") {
+    const result = await postToChat(apiKey, context as ChatMessage);
     return result;
   }
 

--- a/workspaces/common/src/actions/data/slack/messages.ts
+++ b/workspaces/common/src/actions/data/slack/messages.ts
@@ -1,0 +1,68 @@
+import { Context } from '@finos/fdc3';
+import { ServerError, ChannelMessage, List } from '../../../types';
+import { WebClient } from '@slack/web-api';
+import { getSlackChannels, getOrCreateChannel, SlackChannel, getChannels } from './channels';
+import { contextToChannelName } from './common';
+import { getUsers } from './users';
+
+const codeMarkdown = '```';
+
+//post messages to channels named for the context type
+export const postToChannel = async (apiKey: string, context: ChannelMessage): Promise<Context> => {
+  const formatMessage = (context: ChannelMessage): string => {
+    if (context.context){
+      return `${context.message} ${codeMarkdown} ${JSON.stringify(context.context)} ${codeMarkdown}`;
+    }
+    return `${context.message}`;
+  };
+  
+  const slackAPI = new WebClient(apiKey);
+  const channels = await  getSlackChannels(apiKey);
+  let channel: SlackChannel | undefined;
+  channel = channels.find((channel)=> {
+        return (channel.name === context.channel);
+  });
+ 
+  if (channel) {
+      await slackAPI.chat.postMessage({
+        channel: channel.id,
+        text: formatMessage(context)
+      });
+    return context;
+  }
+
+  throw new ServerError('channel could not be found');
+};
+
+//post messages to channels named for the context type
+export const postToContextChannel = async (apiKey: string, context: Context): Promise<Context> => {
+  const slackAPI = new WebClient(apiKey);
+  const formatMessage = (context: Context): string => {
+    return `*New Context Shared* ${codeMarkdown}${JSON.stringify(context)}${codeMarkdown}`
+  };
+
+  const channel = await getOrCreateChannel(apiKey, contextToChannelName(context));
+  if (channel?.id?.slack) {
+    await slackAPI.chat.postMessage({
+      channel: channel.id.slack,
+      text: formatMessage(context)
+    });
+    return context;
+  }
+
+    throw new ServerError('channel could not be found or created');
+  };
+
+  export const getMessageTargets = async (apiKey: string): Promise<List> => {
+    const channels = await getChannels(apiKey);
+    const users = await getUsers(apiKey);
+    return {
+      type: 'connect.list',
+      listType: 'fdc3.context',
+      items: [
+        ...users.items,
+        ...channels.items,
+      ]
+    };
+
+  }

--- a/workspaces/common/src/actions/data/slack/users.ts
+++ b/workspaces/common/src/actions/data/slack/users.ts
@@ -5,9 +5,7 @@ import { List } from '../../../types';
 export const getUsers =  async (apiKey:  string): Promise<List> => {
     const slackAPI = new WebClient(apiKey);
 
-    const users = await slackAPI.users.list({
-
-    });
+    const users = await slackAPI.users.list({});
     //filter out bot and restricted users
     const members = users.members.filter((user) => {
         if (user.deleted) {
@@ -34,7 +32,7 @@ export const getUsers =  async (apiKey:  string): Promise<List> => {
             name: user.name,
             id: {
                 email: user.profile.email,
-                slackId: user.id,
+                slack: user.id,
                 teamId: user.team_id
 
             }
@@ -48,3 +46,19 @@ export const getUsers =  async (apiKey:  string): Promise<List> => {
     }
 
 };
+
+export const decorateContact = async (apiKey: string, contact: Contact): Promise<Contact> => {
+    if (!contact.id.email) {
+        return contact;
+    }
+    const slackAPI = new WebClient(apiKey);
+
+    const users = await slackAPI.users.list({});
+    const found = users.members.filter((user) => {
+        return user.profile.email === contact.id.email;
+    });
+    if (found.length > 0){
+        contact.id.slack = found[0].id;
+    }
+    return contact;
+}

--- a/workspaces/common/src/actions/data/slack/users.ts
+++ b/workspaces/common/src/actions/data/slack/users.ts
@@ -1,0 +1,50 @@
+import { UsersListArguments, WebClient } from '@slack/web-api';
+import { Contact } from '@finos/fdc3';
+import { List } from '../../../types';
+
+export const getUsers =  async (apiKey:  string): Promise<List> => {
+    const slackAPI = new WebClient(apiKey);
+
+    const users = await slackAPI.users.list({
+
+    });
+    //filter out bot and restricted users
+    const members = users.members.filter((user) => {
+        if (user.deleted) {
+            return false;
+        }
+        if (user.is_bot){
+            return false;
+        }
+        if (!user.is_email_confirmed){
+            return false;
+        }
+        if (user.is_restricted){
+            return false;
+        }
+        if (!user.profile.email){
+            return false;
+        }
+        return true;
+    });
+
+    const mappedUsers = members.map((user) => {
+        return {
+            type: 'fdc3.contact',
+            name: user.name,
+            id: {
+                email: user.profile.email,
+                slackId: user.id,
+                teamId: user.team_id
+
+            }
+        } as Contact;
+    });
+
+    return {
+        type: "connect.list",
+        listType: "fdc3.contact",
+        items: mappedUsers
+    }
+
+};

--- a/workspaces/common/src/actions/index.ts
+++ b/workspaces/common/src/actions/index.ts
@@ -7,6 +7,7 @@ import { emailLink } from './link/email';
 import { slackLink } from './link/slack';
 import { polygonIOHandler } from './data/polygon';
 import { openAIHandler } from './data/openAI';
+import { slackAPIHandler } from './data/slack';
 
 const ActionsMap = () => {
   const actions: Map<string, LinkActionHandler | DataActionHandler> = new Map();
@@ -28,5 +29,6 @@ actions.addHandler('slackLink', slackLink);
 actions.addHandler('teamsLink', teamsLink);
 actions.addHandler('polygonIO', polygonIOHandler);
 actions.addHandler('openAI', openAIHandler);
+actions.addHandler('slackAPI', slackAPIHandler);
 
 export const actionsMap = actions;

--- a/workspaces/common/src/types.ts
+++ b/workspaces/common/src/types.ts
@@ -1,4 +1,4 @@
-import type { Context } from '@finos/fdc3';
+import type { Context, Contact } from '@finos/fdc3';
 
 export class ServerError extends Error {
   constructor(message: string) {
@@ -122,17 +122,14 @@ export interface Query extends Context {
 
 export interface ChannelMessage extends Context {
   type: 'connect.channelMessage';
-  channel: string;
+  channel: Channel;
   message: string;
   context?: Context;
 }
 
 export interface ChatMessage extends Context {
   type: 'connect.chatMessage';
-  target: {
-    channel?: string;
-    users?: Array<string>
-  },
+  target: Contact;
   message: string;
   context?: Context;
 }
@@ -159,4 +156,6 @@ export enum ContextTypes {
   Prompt = 'connect.prompt',
   Summary = 'connect.summary',
   ChannelMessage = 'connect.channelMessage',
+  ChatMessage = 'connect.chatMessage',
+  Channel = 'connect.channel',
 }

--- a/workspaces/common/src/types.ts
+++ b/workspaces/common/src/types.ts
@@ -120,6 +120,34 @@ export interface Query extends Context {
   modifiers?: { [key: string]: string };
 }
 
+export interface ChannelMessage extends Context {
+  type: 'connect.channelMessage';
+  channel: string;
+  message: string;
+  context?: Context;
+}
+
+export interface ChatMessage extends Context {
+  type: 'connect.chatMessage';
+  target: {
+    channel?: string;
+    users?: Array<string>
+  },
+  message: string;
+  context?: Context;
+}
+
+export interface Channel extends Context {
+  type: 'connect.channel';
+  id: {
+    slack?: string;
+    teams?: string;
+    fdc3?: string;
+  },
+  name: string;
+}
+
+
 export enum ContextTypes {
   CompanyDetails = 'connect.companyDetails',
   Completion = 'connect.completion',
@@ -130,4 +158,5 @@ export enum ContextTypes {
   Query = 'connect.query',
   Prompt = 'connect.prompt',
   Summary = 'connect.summary',
+  ChannelMessage = 'connect.channelMessage',
 }


### PR DESCRIPTION
Added the following actions support for Slack:

- PostToChannel : either post a `connect.channelMessage` to a specific channel, or post a context to a context specific channel. (e.g. if a 'fdc3.instrument' type is sent to PostToChannel, the handler will post the context to the 'fdc3-instrument' channel - creating the channel if needed)
- PostToChat: post a DM to a contact
- GetChannels : returns all channels as a `connect.list` context of `connect.channel` contexts
- GetOrCreateChannel : gets the channel object, and creates if it doesn't exist. returns a `connect.channel` context
- GetUsers : returns all users for the team as a `connect.list` context of `fdc3.contact` contexts
- GetMessageTarget : returns a combined list of users and channels where a message can be posted. returns a `connect.list` context