### PR TITLE
added 3 different example "assistants" for instruments

### DIFF
--- a/workspaces/common/src/actions/data/openAI/common.ts
+++ b/workspaces/common/src/actions/data/openAI/common.ts
@@ -1,0 +1,163 @@
+import { ResponseFormatJSONSchema } from 'openai/resources';
+
+export const summarySchema: ResponseFormatJSONSchema.JSONSchema = {
+  "name": "summary",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": ["connect.summary"]
+      },
+      "title": {
+        "type": "string"
+      },
+      "text": {
+        "type": "string"
+      }
+    },
+    "required": ["type", "title", "text"]
+  }
+};
+
+export const instrumentListSchema: ResponseFormatJSONSchema.JSONSchema = {
+    "name": "instrumentList",
+    "schema": {
+        "type": "object",
+        "properties": {
+        "type": {
+            "const": "fdc3.instrumentList"
+        },
+        "instruments": {
+            "type": "array",
+            "title": "List of instruments",
+            "description": "An array of instrument contexts that forms the list.",
+            "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "const": "fdc3.instrument"
+                  },
+                  "id": {
+                    "title": "Instrument identifiers",
+                    "description": "Any combination of instrument identifiers can be used together to resolve ambiguity, or for a better match. Not all applications will use the same instrument identifiers, which is why FDC3 allows for multiple to be specified. In general, the more identifiers an application can provide, the easier it will be to achieve interoperability.\n\nIt is valid to include extra properties and metadata as part of the instrument payload, but the minimum requirement is for at least one instrument identifier to be provided.\n\nTry to only use instrument identifiers as intended. E.g. the `ticker` property is meant for tickers as used by an exchange.\nIf the identifier you want to share is not a ticker or one of the other standardized fields, define a property that makes it clear what the value represents. Doing so will make interpretation easier for the developers of target applications.",
+                    "type": "object",
+                    "properties": {
+                      "BBG": {
+                        "type": "string",
+                        "title": "Bloomberg security",
+                        "description": "<https://www.bloomberg.com/>"
+                      },
+                      "CUSIP": {
+                        "type": "string",
+                        "title": "CUSIP",
+                        "description": "<https://www.cusip.com/>"
+                      },
+                      "FDS_ID": {
+                        "type": "string",
+                        "title": "FactSet Permanent Security Identifier",
+                        "description": "<https://www.factset.com/>"
+                      },
+                      "FIGI": {
+                        "type": "string",
+                        "title": "Open FIGI",
+                        "description": "<https://www.openfigi.com/>"
+                      },
+                      "ISIN": {
+                        "type": "string",
+                        "title": "ISIN",
+                        "description": "<https://www.isin.org/>"
+                      },
+                      "PERMID": {
+                        "type": "string",
+                        "title": "Refinitiv PERMID",
+                        "description": "<https://permid.org/>"
+                      },
+                      "RIC": {
+                        "type": "string",
+                        "title": "Refinitiv Identification Code",
+                        "description": " <https://www.refinitiv.com/>"
+                      },
+                      "SEDOL": {
+                        "type": "string",
+                        "title": "SEDOL",
+                        "description": "<https://www.lseg.com/sedol>"
+                      },
+                      "ticker": {
+                        "type": "string",
+                        "title": "Stock ticker",
+                        "description": "Unstandardized stock tickers"
+                      }
+                    }
+                  },
+                  "market": {
+                    "description": "The `market` map can be used to further specify the instrument and help achieve interoperability between disparate data sources. This is especially useful when using an `id` field that is not globally unique.",
+                    "type": "object",
+                    "properties": {
+                      "MIC": {
+                        "type": "string",
+                        "title": "Market Identifier Code",
+                        "description": "<https://en.wikipedia.org/wiki/Market_Identifier_Code>"
+                      },
+                      "name": {
+                        "type": "string",
+                        "title": "Market Name",
+                        "description": "Human readable market name"
+                      },
+                      "COUNTRY_ISOALPHA2": {
+                        "type": "string",
+                        "title": "Country ISO Code",
+                        "description": "<https://www.iso.org/iso-3166-country-codes.html>"
+                      },
+                      "BBG": {
+                        "type": "string",
+                        "title": "Bloomberg Market Identifier",
+                        "description": "<https://www.bloomberg.com/>"
+                      }
+                    },
+                    "unevaluatedProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "type","id"
+                ]
+              },
+            }
+        },
+        "required": [
+        "instruments"
+        ]
+    }
+}
+
+export const summaryDataReturnPrompt = `
+Return the summary as a JSON object using the following interface:
+"
+  {
+    type: 'connect.summary';
+    title: string;
+    text: string;
+  }
+"
+`;
+
+export const similarCompaniesDataReturnPrompt = `
+Return the similar companies as a FDC3 Context Data JSON object of the type 'fdc3.instrumentList' using the following interfaces:
+
+  interface InstrumentList {
+    type: 'fdc3.instrumentList';
+    instruments: Array<Instrument>;
+  }
+
+  interface Instrument {
+    type: 'fdc3.instrument';
+    name?: string;
+    id: {
+      ticker?: string;
+    }
+  }
+
+  Include both the company name and ticker for each company in the 'fdc3.instrument' object. 
+`;

--- a/workspaces/common/src/actions/data/openAI/financeAssistant-contrarian.ts
+++ b/workspaces/common/src/actions/data/openAI/financeAssistant-contrarian.ts
@@ -1,0 +1,101 @@
+import type { Context, InstrumentList } from '@finos/fdc3';
+import { Summary, ServerError } from '../../../types';
+import OpenAI from 'openai';
+import { OPENAI_MODEL } from '.';
+import { summarySchema, instrumentListSchema, similarCompaniesDataReturnPrompt, summaryDataReturnPrompt } from './common';
+
+const mainSystemPrompt: string = `You are an assistant providing information about publicly traded companies with a contrarian point of view.`;
+
+export const getCompanyContrarianSummary = async ( apiKey: string, context: Context ): Promise<Summary> => {
+  const openai = new OpenAI({ apiKey: apiKey });
+
+const summaryDetailsPrompt = `
+  You provide company summaries with a contrarian POV as markdown formatted string in the 'text' field of the JSON output.
+  Here is an example output:
+  {
+      type: 'connect.summary';
+      title: '<Company Name> (<Ticker Name>) - Summary',
+      text: 
+        <Company Synopsis>
+        #### Contrarian Summary of <Ticker>
+        <Contrarian Summary>
+        #### Contrarian Risks
+        <List Risks>
+        #### Contrarian Bottom Line
+        <Conclusions>
+      
+    }
+
+`;
+const summaryPrompt = (context: Context): string => `
+    Please provide a summary of the the company ${context.name} with the ticker symbol ${context.id?.ticker}
+`;
+  const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+  messages.push({ 
+    role: 'system', 
+    content: `
+    ${mainSystemPrompt} 
+    ${summaryDetailsPrompt}
+    ${summaryDataReturnPrompt}
+    ` 
+  });
+  messages.push({ role: 'user', content: summaryPrompt(context) });
+
+  const chatCompletion = await openai.chat.completions.create({
+    messages,
+    model: OPENAI_MODEL,
+    response_format: {type:"json_schema", json_schema: summarySchema}
+  });
+
+  if (chatCompletion?.choices.length > 0) {
+    const message = chatCompletion.choices[0].message.content;
+    if (message) {
+      const summary: Summary = JSON.parse(message);
+      if (summary) {
+        return summary;
+      }
+    }
+  }
+
+  return {
+    type: 'connect.summary',
+    title: 'Error',
+    text: 'Summary could not be generated',
+  };
+};
+
+const similarPrompt = (context: Context): string => `
+    Please provide a list of similar companies from a contrarian perspective to ${context.name} with the ticker symbol ${context.id?.ticker}.
+    Return the list as an FDC3 instrumentList JSON object.
+`;
+export const getSimilarContrarianCompanies = async ( apiKey: string, context: Context ): Promise<InstrumentList> => {
+  const openai = new OpenAI({ apiKey: apiKey });
+
+  const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+  messages.push({ 
+    role: 'system', 
+    content: `${mainSystemPrompt} 
+    You will identify companies that have similar characteristics from a contrarian POV, by industry, business model, and other characteristics of the companies involved.
+    ${similarCompaniesDataReturnPrompt}
+    ` 
+  });
+  messages.push({ role: 'user', content: similarPrompt(context) });
+
+  const chatCompletion = await openai.chat.completions.create({
+    messages,
+    model: OPENAI_MODEL,
+    response_format: {type:"json_schema", json_schema: instrumentListSchema}
+  });
+
+  if (chatCompletion?.choices.length > 0) {
+    const message = chatCompletion.choices[0].message.content;
+    if (message) {
+      const list: InstrumentList = JSON.parse(message);
+      if (list) {
+        return list;
+      }
+    }
+  }
+
+  throw new ServerError('similar companies could not be found');
+};

--- a/workspaces/common/src/actions/data/openAI/financeAssistant-growth.ts
+++ b/workspaces/common/src/actions/data/openAI/financeAssistant-growth.ts
@@ -1,0 +1,100 @@
+import type { Context, InstrumentList } from '@finos/fdc3';
+import { Summary, ServerError } from '../../../types';
+import OpenAI from 'openai';
+import { OPENAI_MODEL } from '.';
+import { summarySchema, instrumentListSchema, similarCompaniesDataReturnPrompt, summaryDataReturnPrompt } from './common';
+
+const mainSystemPrompt: string = `You are an assistant providing information about publicly traded companies with a growth point of view.`;
+
+export const getCompanyGrowthSummary = async ( apiKey: string, context: Context ): Promise<Summary> => {
+  const openai = new OpenAI({ apiKey: apiKey });
+
+const summaryDetailsPrompt = `
+  You provide company summaries with a growth POV as markdown formatted string in the 'text' field of the JSON output.
+  Here is an example output:
+  {
+      type: 'connect.summary';
+      title: '<Company Name> (<Ticker Name>) - Summary',
+      text: 
+        <Company Synopsis>
+        #### Growth Perspective of <Ticker>
+        <Growth Perspective>
+        #### Potential Growth Challenges
+        <List Challenges>
+        #### Growth Outlook: <Outlook>
+        <Conclusions>
+      
+    }
+`;
+const summaryPrompt = (context: Context): string => `
+    Please provide a summary of the the company ${context.name} with the ticker symbol ${context.id?.ticker}
+`;
+  const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+  messages.push({ 
+    role: 'system', 
+    content: `
+    ${mainSystemPrompt} 
+    ${summaryDetailsPrompt}
+    ${summaryDataReturnPrompt}
+    ` 
+  });
+  messages.push({ role: 'user', content: summaryPrompt(context) });
+
+  const chatCompletion = await openai.chat.completions.create({
+    messages,
+    model: OPENAI_MODEL,
+    response_format: {type:"json_schema", json_schema: summarySchema}
+  });
+
+  if (chatCompletion?.choices.length > 0) {
+    const message = chatCompletion.choices[0].message.content;
+    if (message) {
+      const summary: Summary = JSON.parse(message);
+      if (summary) {
+        return summary;
+      }
+    }
+  }
+
+  return {
+    type: 'connect.summary',
+    title: 'Error',
+    text: 'Summary could not be generated',
+  };
+};
+
+const similarPrompt = (context: Context): string => `
+    Please provide a list of similar companies from a growth perspective to ${context.name} with the ticker symbol ${context.id?.ticker}.
+    Return the list as an FDC3 instrumentList JSON object.
+`;
+export const getSimilarGrowthCompanies = async ( apiKey: string, context: Context ): Promise<InstrumentList> => {
+  const openai = new OpenAI({ apiKey: apiKey });
+
+  const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+  messages.push({ 
+    role: 'system', 
+    content: `${mainSystemPrompt} 
+    You will identify similar companies, with a growth focus, by industry, business model, and other characteristics of the companies involved.
+    ${similarCompaniesDataReturnPrompt}
+    ` 
+  });
+  messages.push({ role: 'user', content: similarPrompt(context) });
+
+  const chatCompletion = await openai.chat.completions.create({
+    messages,
+    model: OPENAI_MODEL,
+    response_format: {type:"json_schema", json_schema: instrumentListSchema}
+  });
+
+  if (chatCompletion?.choices.length > 0) {
+    const message = chatCompletion.choices[0].message.content;
+    if (message) {
+      const list: InstrumentList = JSON.parse(message);
+      if (list) {
+        return list;
+      }
+    }
+  }
+
+  throw new ServerError('similar companies could not be found');
+};

--- a/workspaces/common/src/actions/data/openAI/financeAssistant.ts
+++ b/workspaces/common/src/actions/data/openAI/financeAssistant.ts
@@ -1,0 +1,102 @@
+import type { Context, InstrumentList } from '@finos/fdc3';
+import { Summary, ServerError } from '../../../types';
+import OpenAI from 'openai';
+import { OPENAI_MODEL } from '.';
+import { summarySchema, instrumentListSchema, similarCompaniesDataReturnPrompt, summaryDataReturnPrompt } from './common';
+
+const mainSystemPrompt: string = `You are an assistant providing objective and accurate information about publicly traded companies.`;
+
+export const getCompanySummary = async ( apiKey: string, context: Context ): Promise<Summary> => {
+  const openai = new OpenAI({ apiKey: apiKey });
+
+const summaryDetailsPrompt = `
+  You provide company summaries as markdown formatted string in the 'text' field of the JSON output.
+  Here is an example output:  
+  {
+      type: 'connect.summary';
+      title: '<Company Name> (<Ticker Name>) - Summary',
+      text: 
+        <Company Synopsis>
+        #### Background
+        <Company Background>
+        #### Industry & Market Overview
+        <Industry & Market Overview>
+        #### Financial Performance
+        <Financial Performance>
+        #### Conclusion & Outlook
+        <Conclusions>
+      
+    }
+`;
+const summaryPrompt = (context: Context): string => `
+    Please provide a summary of the the company ${context.name} with the ticker symbol ${context.id?.ticker}
+`;
+  const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+  messages.push({ 
+    role: 'system', 
+    content: `
+    ${mainSystemPrompt} 
+    ${summaryDetailsPrompt}
+    ${summaryDataReturnPrompt}
+    ` 
+  });
+  messages.push({ role: 'user', content: summaryPrompt(context) });
+
+  const chatCompletion = await openai.chat.completions.create({
+    messages,
+    model: OPENAI_MODEL,
+    response_format: {type:"json_schema", json_schema: summarySchema}
+  });
+
+  if (chatCompletion?.choices.length > 0) {
+    const message = chatCompletion.choices[0].message.content;
+    if (message) {
+      const summary: Summary = JSON.parse(message);
+      if (summary) {
+        return summary;
+      }
+    }
+  }
+
+  return {
+    type: 'connect.summary',
+    title: 'Error',
+    text: 'Summary could not be generated',
+  };
+};
+
+const similarPrompt = (context: Context): string => `
+    Please provide a list of companies similar to ${context.name} with the ticker symbol ${context.id?.ticker}.
+    Return the list as an FDC3 instrumentList JSON object.
+`;
+export const getSimilarCompanies = async ( apiKey: string, context: Context ): Promise<InstrumentList> => {
+  const openai = new OpenAI({ apiKey: apiKey });
+
+  const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+  messages.push({ 
+    role: 'system', 
+    content: `${mainSystemPrompt} 
+    You will identify similar companies by industry, business model, and other characteristics of the companies involved.
+    ${similarCompaniesDataReturnPrompt}
+    ` 
+  });
+  messages.push({ role: 'user', content: similarPrompt(context) });
+
+  const chatCompletion = await openai.chat.completions.create({
+    messages,
+    model: OPENAI_MODEL,
+    response_format: {type:"json_schema", json_schema: instrumentListSchema}
+  });
+
+  if (chatCompletion?.choices.length > 0) {
+    const message = chatCompletion.choices[0].message.content;
+    if (message) {
+      const list: InstrumentList = JSON.parse(message);
+      if (list) {
+        return list;
+      }
+    }
+  }
+
+  throw new ServerError('similar companies could not be found');
+};

--- a/workspaces/common/src/actions/data/openAI/index.ts
+++ b/workspaces/common/src/actions/data/openAI/index.ts
@@ -9,6 +9,9 @@ import { summarize } from './summarize';
 import { findSimilar } from './findSimilar';
 import { generatePrompt } from './generatePrompt';
 import { getEntities } from './getEntities';
+import { getCompanySummary, getSimilarCompanies } from './financeAssistant';
+import { getCompanyContrarianSummary, getSimilarContrarianCompanies } from './financeAssistant-contrarian';
+import { getCompanyGrowthSummary, getSimilarGrowthCompanies } from './financeAssistant-growth';
 
 const apiKey = process.env.OPEN_AI_API_KEY;
 
@@ -31,6 +34,54 @@ export const openAIHandler: DataActionHandler = async (params) => {
       return findSimilar(apiKey, context);
     case "GetEntities":
       return getEntities(apiKey, context);
+    default:
+      throw new RequestError('intent not supported');
+  }
+};
+
+export const openAIFinanceAssistantHandler: DataActionHandler = async (params) => {
+  if (!apiKey) {
+    throw new ServerError('openAI api key missing');
+  }
+  
+  const { context, intent } = params;
+  switch (intent) {
+    case "Summarize":
+      return getCompanySummary(apiKey, context);
+    case "FindSimilar":
+      return getSimilarCompanies(apiKey, context);
+    default:
+      throw new RequestError('intent not supported');
+  }
+};
+
+export const openAIGrowthFinanceAssistantHandler: DataActionHandler = async (params) => {
+  if (!apiKey) {
+    throw new ServerError('openAI api key missing');
+  }
+  
+  const { context, intent } = params;
+  switch (intent) {
+    case "Summarize":
+      return getCompanyGrowthSummary(apiKey, context);
+    case "FindSimilar":
+      return getSimilarGrowthCompanies(apiKey, context);
+    default:
+      throw new RequestError('intent not supported');
+  }
+};
+
+export const openAIContrarianFinanceAssistantHandler: DataActionHandler = async (params) => {
+  if (!apiKey) {
+    throw new ServerError('openAI api key missing');
+  }
+  
+  const { context, intent } = params;
+  switch (intent) {
+    case "Summarize":
+      return getCompanyContrarianSummary(apiKey, context);
+    case "FindSimilar":
+      return getSimilarContrarianCompanies(apiKey, context);
     default:
       throw new RequestError('intent not supported');
   }

--- a/workspaces/common/src/actions/index.ts
+++ b/workspaces/common/src/actions/index.ts
@@ -6,7 +6,7 @@ import { companyHQLink } from './link/polygon';
 import { emailLink } from './link/email';
 import { slackLink } from './link/slack';
 import { polygonIOHandler } from './data/polygon';
-import { openAIHandler } from './data/openAI';
+import { openAIHandler, openAIFinanceAssistantHandler, openAIContrarianFinanceAssistantHandler, openAIGrowthFinanceAssistantHandler } from './data/openAI';
 
 const ActionsMap = () => {
   const actions: Map<string, LinkActionHandler | DataActionHandler> = new Map();
@@ -28,5 +28,8 @@ actions.addHandler('slackLink', slackLink);
 actions.addHandler('teamsLink', teamsLink);
 actions.addHandler('polygonIO', polygonIOHandler);
 actions.addHandler('openAI', openAIHandler);
+actions.addHandler('openAI-financeAssistant', openAIFinanceAssistantHandler);
+actions.addHandler('openAI-growthAssistant', openAIGrowthFinanceAssistantHandler);
+actions.addHandler('openAI-contrarianAssistant', openAIContrarianFinanceAssistantHandler);
 
 export const actionsMap = actions;


### PR DESCRIPTION
Created 3 example 'assistants' that use different prompt structures to handle the same intents with different behavior. 
- A standard watchlist 'assistant' that provides summary and find similar functions in an an objective way
- A 'contrarian assistant' that puts a contrarian POV on its analysis
- A 'growth assistant' that brings a growth POV

This is what resolver looks like in the watch list demo:
<img width="746" alt="image" src="https://github.com/user-attachments/assets/10d15719-98ba-4f8c-9649-469bdaeef76c" />
Contrarian Response:
<img width="675" alt="image" src="https://github.com/user-attachments/assets/4ec4e454-03e2-4b57-abd7-fb5c4f0b90e1" />
Growth Response:
<img width="687" alt="image" src="https://github.com/user-attachments/assets/23257a38-733b-4f4b-a95f-0e628b26339d" />
Standard:
<img width="672" alt="image" src="https://github.com/user-attachments/assets/88f4dab6-c5e3-4fe8-bbfe-512750da4328" />

